### PR TITLE
ocaml-qmp: Use float to represent message timestamps

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+0.9.1 (29-May-2013):
+* Change representation of message timestamps from a tuple of ints to
+  a float.  This avoids problems on 32-bit architectures and  follows 
+  the example of the OCaml standard library.
+
 0.9.0 (29-May-2013):
 * first public release
 

--- a/lib/qmp.mli
+++ b/lib/qmp.mli
@@ -32,9 +32,8 @@ type greeting = {
 }
 
 type event = {
-  secs : int;       (** time the event occurred in secs ... *)
-  usecs : int;      (** ... and usecs *)
-  event : string;   (** type of event *)
+  timestamp : float; (** time the event occurred in seconds *)
+  event : string;    (** type of event *)
 }
 
 type error = { cls : string; descr : string; }

--- a/lib_test/messages.ml
+++ b/lib_test/messages.ml
@@ -21,7 +21,7 @@ let files = [
   "capabilities.json",          Command (None, Qmp_capabilities);
   "error.json",                 Error (None, { cls="JSONParsing"; descr="Invalid JSON syntax" });
   "greeting.json",              Greeting { major = 1; minor = 1; micro = 0; package = " (Debian 1.1.0+dfsg-1)" };
-  "powerdown.json",             Event { secs = 1258551470; usecs = 802384; event = "POWERDOWN" };
+  "powerdown.json",             Event { timestamp = 1258551470.802384; event = "POWERDOWN" };
   "query-commands.json",        Command (None, Query_commands);
   "query-commands-return.json", Success (None, Name_list [ "qom-list-types"; "change-vnc-password" ]);
   "query_kvm.json",             Command (Some "example", Query_kvm);
@@ -31,7 +31,7 @@ let files = [
   "eject.json",                 Command (None, Eject "ide1-cd0");
   "query-status.json",          Command (None, Query_status);
   "query-status-result.json",   Success (None, Status "running");
-  "block-io-error.json",        Event { secs = 1265044230; usecs = 450486; event = "BLOCK_IO_ERROR" };
+  "block-io-error.json",        Event { timestamp = 1265044230.450486; event = "BLOCK_IO_ERROR" };
 ]
 
 let string_of_file filename =

--- a/qmp.obuild
+++ b/qmp.obuild
@@ -1,5 +1,5 @@
 name: qmp
-version: 0.9.0
+version: 0.9.1
 synopsis: Qemu Message Protocol (QMP) client for OCaml
 obuild-ver: 1
 


### PR DESCRIPTION
On 32-bit platforms max_int is 2^30-1, so 32-bit Unix timestamps
can't be represented.   The OCaml standard library uses floats
to represent timestamps, so we will follow suit.

Signed-off-by: Euan Harris euan.harris@citrix.com
