### PR TITLE
Introduce Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: c
+sudo: required
+install:
+  - wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-opam.sh
+script:
+  - bash -ex .travis-opam.sh
+env:
+  matrix:
+    - OCAML_VERSION=4.02 BASE_REMOTE=git://github.com/xapi-project/xs-opam
+    - OCAML_VERSION=latest EXTRA_REMOTES=git://github.com/xapi-project/xs-opam
+matrix:
+  fast_finish: true
+  allow_failures:
+    - env: OCAML_VERSION=latest EXTRA_REMOTES=git://github.com/xapi-project/xs-opam
+

--- a/lib_test/messages.ml
+++ b/lib_test/messages.ml
@@ -12,7 +12,7 @@
  * GNU Lesser General Public License for more details.
  *)
 
-open OUnit
+open OUnit2
 open Qmp
 
 let my_dir = "lib_test"
@@ -44,22 +44,16 @@ let string_of_file filename =
   close_in ic;
   String.concat "\n" (List.rev !lines)
 
-let test_message_of_string (filename, expected) () =
+let test_message_of_string (filename, expected) test_ctxt =
   let txt = string_of_file filename in
   let actual = Qmp.message_of_string txt in
   assert_equal ~printer:Qmp.string_of_message expected actual
 
-let parse_print expected () =
+let parse_print expected test_ctxt =
   let actual = Qmp.message_of_string (Qmp.string_of_message expected) in
   assert_equal ~printer:Qmp.string_of_message expected actual
 
 let _ =
-  let verbose = ref false in
-  Arg.parse [
-    "-verbose", Arg.Unit (fun _ -> verbose := true), "Run in verbose mode";
-  ] (fun x -> Printf.fprintf stderr "Ignoring argument: %s" x)
-    "Test message parsing/printing code";
-
   let message_of_string = "message_of_string" >::: (List.map (fun (filename, expected) ->
     filename >:: (test_message_of_string (filename, expected))
   ) files) in
@@ -72,7 +66,7 @@ let _ =
       message_of_string;
       parse_print;
     ] in
-  run_test_tt ~verbose:!verbose suite
+  run_test_tt_main suite
 
 
 

--- a/opam
+++ b/opam
@@ -1,0 +1,31 @@
+opam-version: "1.2"
+maintainer: "xen-api@lists.xen.org"
+authors: [ "Dave Scott" ]
+homepage: "https://github.com/xapi-project/ocaml-qmp"
+bug-reports: "https://github.com/xapi-project/ocaml-qmp/issues"
+tags: [
+  "org:mirage"
+  "org:xapi-project"
+]
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+build-test: [
+  ["./configure" "--prefix" prefix "--enable-tests"]
+  [make "test"]
+]
+install: [make "install" "BINDIR=%{bin}%"]
+remove: [
+  [make "uninstall" "BINDIR=%{bin}%"]
+  ["ocamlfind" "remove" "qmp"]
+]
+depends: [
+  "base-unix"
+  "oasis"     {build}
+  "ocamlfind" {build}
+  "yojson"
+  "cmdliner"
+  "ounit"     {test}
+]
+dev-repo: "git://github.com/xapi-project/ocaml-qmp"


### PR DESCRIPTION
There are actually two failures due to rounding errors that are not invalidating the tests. This will need further investigation but I think is out of scope for this PR.

```
ocaml setup.ml -test
....................F............F
==============================================================================
Failure: qmp:1:parse_print:16:block-io-error.json
expected: {"event":"BLOCK_IO_ERROR","timestamp":{"seconds":1265044230,"microseconds":450485}}
but got: {"event":"BLOCK_IO_ERROR","timestamp":{"seconds":1265044230,"microseconds":450484}}
------------------------------------------------------------------------------
==============================================================================
Failure: qmp:1:parse_print:3:powerdown.json
expected: {"event":"POWERDOWN","timestamp":{"seconds":1258551470,"microseconds":802383}}
but got: {"event":"POWERDOWN","timestamp":{"seconds":1258551470,"microseconds":802382}}
------------------------------------------------------------------------------
Ran: 34 tests in: 0.01 seconds.
FAILED: Cases: 34 Tried: 34 Errors: 0 Failures: 2 Skip:  0 Todo: 0 Timeouts: 0.
```