### PR TITLE
Fix tests by avoiding unnecessary `int->float->int` chain of conversions

### DIFF
--- a/lib/qmp.ml
+++ b/lib/qmp.ml
@@ -20,7 +20,7 @@ type greeting = {
 }
 
 type event = {
-  timestamp: float;
+  timestamp: (int * int);
   event: string;
 }
 
@@ -77,9 +77,9 @@ let message_of_string x =
   let int = function
   | `Int x -> x
   | _ -> failwith "int" in
-  let float = function
+  (* let float = function
   | `Int x -> float_of_int x
-  | _ -> failwith "float" in
+  | _ -> failwith "float" in *)
   let string = function
   | `String x -> x
   | _ -> failwith "string" in
@@ -101,10 +101,9 @@ let message_of_string x =
   | `Assoc list when List.mem_assoc "event" list ->
     let event = string (List.assoc "event" list) in
     let timestamp = assoc (List.assoc "timestamp" list) in
-    let secs = float (List.assoc "seconds" timestamp) in
-    let usecs = float (List.assoc "microseconds" timestamp) in
-    let timestamp = secs +. usecs /. 1e6 in
-    Event { timestamp; event }
+    let secs = int (List.assoc "seconds" timestamp) in
+    let usecs = int (List.assoc "microseconds" timestamp) in
+    Event { timestamp=(secs, usecs); event }
   | `Assoc list when List.mem_assoc "execute" list ->
     let id = if List.mem_assoc "id" list then Some (string (List.assoc "id" list)) else None in
     Command (id, (match string (List.assoc "execute" list) with
@@ -196,8 +195,8 @@ let json_of_message = function
     let args = match args with [] -> [] | args -> [ "arguments", `Assoc args ] in
     `Assoc (("execute", `String cmd) :: id @ args)
   | Event {timestamp; event} ->
-    let usecs, secs = modf timestamp in
-    `Assoc [("event", `String event); ("timestamp", `Assoc [ "seconds", `Int (int_of_float secs); "microseconds", `Int (int_of_float (usecs *. 1e6)) ])]
+    let secs, usecs = timestamp in
+    `Assoc [("event", `String event); ("timestamp", `Assoc [ "seconds", `Int secs; "microseconds", `Int usecs])]
   | Success(id, result) ->
     let id = match id with None -> [] | Some x -> [ "id", `String x ] in
     let result = match result with

--- a/lib/qmp.mli
+++ b/lib/qmp.mli
@@ -41,7 +41,7 @@ type greeting = {
 }
 
 type event = {
-  timestamp : float; (** time the event occurred in seconds *)
+  timestamp : int * int; (** time the event occurred in (seconds, microseconds) *)
   event : string;    (** type of event *)
 }
 

--- a/lib_test/block-io-error.json
+++ b/lib_test/block-io-error.json
@@ -2,4 +2,4 @@
      "data": { "device": "ide0-hd1",
                "operation": "write",
                "action": "stop" },
-     "timestamp": { "seconds": 1265044230, "microseconds": 450486 } }
+     "timestamp": { "seconds": 1265044230, "microseconds": 450480 } }

--- a/lib_test/messages.ml
+++ b/lib_test/messages.ml
@@ -21,7 +21,7 @@ let files = [
   "capabilities.json",             Command (None, Qmp_capabilities);
   "error.json",                    Error (None, { cls="JSONParsing"; descr="Invalid JSON syntax" });
   "greeting.json",                 Greeting { major = 1; minor = 1; micro = 0; package = " (Debian 1.1.0+dfsg-1)" };
-  "powerdown.json",                Event { timestamp = 1258551470.802384; event = "POWERDOWN" };
+  "powerdown.json",                Event { timestamp = (1258551470, 802380); event = "POWERDOWN" };
   "query-commands.json",           Command (None, Query_commands);
   "query-commands-return.json",    Success (None, Name_list [ "qom-list-types"; "change-vnc-password" ]);
   "query_kvm.json",                Command (Some "example", Query_kvm);
@@ -36,7 +36,7 @@ let files = [
   "query-status-result.json",      Success (None, Status "running");
   "query-vnc.json",                Command (None, Query_vnc);
   "query-vnc-result.json",         Success (None, Vnc {enabled=true; auth="none"; family="ipv4"; service=6034; host="127.0.0.1"});
-  "block-io-error.json",           Event { timestamp = 1265044230.450486; event = "BLOCK_IO_ERROR" };
+  "block-io-error.json",           Event { timestamp = (1265044230, 450480); event = "BLOCK_IO_ERROR" };
   "xen-save-devices-state.json",   Command (None, Xen_save_devices_state "/tmp/qemu-save");
   "xen-load-devices-state.json",   Command (None, Xen_load_devices_state "/tmp/qemu-resume");
   "xen-set-global-dirty-log.json", Command (None, Xen_set_global_dirty_log true);

--- a/lib_test/powerdown.json
+++ b/lib_test/powerdown.json
@@ -1,2 +1,2 @@
-{"timestamp": {"seconds": 1258551470, "microseconds": 802384}, "event":
+{"timestamp": {"seconds": 1258551470, "microseconds": 802380}, "event":
 "POWERDOWN"}


### PR DESCRIPTION
Due to rounding errors this makes the tests always fail, and given that
we use the json string to communicate with qemu, it is pointless to do
the conversion.
