### PR TITLE
CP-22500: add support for QMP messages for xen platform pv driver info in upstream qemu

### DIFF
--- a/lib/qmp.ml
+++ b/lib/qmp.ml
@@ -80,6 +80,18 @@ type message =
   | Success of (id option * result)
   | Event of event
 
+module Event = struct
+
+  (* Emitted when XEN PV driver write build number to io-port 0x10,
+     marking the end of preamble:
+   # <- { "event": "XEN_PLATFORM_PV_DRIVER_INFO",
+   #      "data": { "product-num": 3, "build-num": 1},
+   #      "timestamp": { "seconds": 1500394278, "microseconds": 878290 } }
+  *)
+  let _XEN_PLATFORM_PV_DRIVER_INFO = "XEN_PLATFORM_PV_DRIVER_INFO"
+end
+
+
 let message_of_string x =
   let int = function
   | `Int x -> x

--- a/lib/qmp.ml
+++ b/lib/qmp.ml
@@ -37,12 +37,18 @@ type vnc = {
   host    : string;
 }
 
+type xen_platform_pv_driver_info = {
+  product_num : int;
+  build_num   : int;
+}
+
 type command =
   | Qmp_capabilities
   | Query_commands
   | Query_kvm
   | Query_status
   | Query_vnc
+  | Query_xen_platform_pv_driver_info
   | Stop
   | Cont
   | Eject of string * bool option
@@ -57,6 +63,7 @@ type result =
   | Enabled of enabled
   | Status of string
   | Vnc of vnc
+  | Xen_platform_pv_driver_info of xen_platform_pv_driver_info
   | Unit
 
 type error = {
@@ -115,6 +122,7 @@ let message_of_string x =
       | "query-status" -> Query_status
       | "query-vnc" -> Query_vnc
       | "query-kvm" -> Query_kvm
+      | "query-xen-platform-pv-driver-info" -> Query_xen_platform_pv_driver_info
       | "eject" ->
             let arguments = assoc (List.assoc "arguments" list) in
             Eject (string (List.assoc "device" arguments),
@@ -150,6 +158,12 @@ let message_of_string x =
           let service = int_of_string (string (List.assoc "service" list)) in
           let host = string (List.assoc "host" list) in
           {enabled; auth; family; service; host})
+      | `Assoc list when List.mem_assoc "product-num" list
+                      && List.mem_assoc "build-num" list ->
+        Xen_platform_pv_driver_info (
+          let product_num = int (List.assoc "product-num" list) in
+          let build_num = int (List.assoc "build-num" list) in
+          {product_num; build_num})
       | `Assoc list when List.mem_assoc "enabled" list ->
         let enabled = bool (List.assoc "enabled" list) in
         let present = bool (List.assoc "present" list) in
@@ -184,6 +198,7 @@ let json_of_message = function
       | Query_status -> "query-status", []
       | Query_vnc -> "query-vnc", []
       | Query_kvm -> "query-kvm", []
+      | Query_xen_platform_pv_driver_info -> "query-xen-platform-pv-driver-info", []
       | Eject (device, None) -> "eject", [ "device", `String device ]
       | Eject (device, Some force) -> "eject", [ "device", `String device; "force", `Bool force ]
       | Change (device, target, None) -> "change", [ "device", `String device; "target", `String target ]
@@ -205,6 +220,7 @@ let json_of_message = function
       | Enabled {enabled; present} -> `Assoc [ "enabled", `Bool enabled; "present", `Bool present ]
       | Name_list xs -> `List (List.map (fun x -> `Assoc [ "name", `String x ]) xs)
       | Vnc {enabled; auth; family; service; host} -> `Assoc [ "enabled", `Bool enabled; "auth", `String auth; "family", `String family; "service", `String (string_of_int service); "host", `String host ]
+      | Xen_platform_pv_driver_info { product_num; build_num } -> `Assoc [ "product-num", `Int product_num; "build-num", `Int build_num; ]
      in
     `Assoc (("return", result) :: id)
   | Error(id, e) ->

--- a/lib/qmp.mli
+++ b/lib/qmp.mli
@@ -25,11 +25,17 @@ type vnc = {
   host    : string;
 }
 
+type xen_platform_pv_driver_info = {
+  product_num : int;
+  build_num   : int;
+}
+
 type result =
     Name_list of string list
   | Enabled of enabled
   | Status of string
   | Vnc of vnc
+  | Xen_platform_pv_driver_info of xen_platform_pv_driver_info
   | Unit
 (** A successful RPC result *)
 
@@ -56,6 +62,7 @@ type command =
   | Query_kvm
   | Query_status
   | Query_vnc
+  | Query_xen_platform_pv_driver_info
   | Stop
   | Cont
   | Eject of string * bool option

--- a/lib_test/messages.ml
+++ b/lib_test/messages.ml
@@ -40,6 +40,8 @@ let files = [
   "xen-save-devices-state.json",   Command (None, Xen_save_devices_state "/tmp/qemu-save");
   "xen-load-devices-state.json",   Command (None, Xen_load_devices_state "/tmp/qemu-resume");
   "xen-set-global-dirty-log.json", Command (None, Xen_set_global_dirty_log true);
+  "query-xen-platform-pv-driver-info.json", Command (None, Query_xen_platform_pv_driver_info);
+  "query-xen-platform-pv-driver-info-result.json", Success (None, Xen_platform_pv_driver_info { product_num=3; build_num=1; });
 ]
 
 let string_of_file filename =

--- a/lib_test/messages.ml
+++ b/lib_test/messages.ml
@@ -42,6 +42,7 @@ let files = [
   "xen-set-global-dirty-log.json", Command (None, Xen_set_global_dirty_log true);
   "query-xen-platform-pv-driver-info.json", Command (None, Query_xen_platform_pv_driver_info);
   "query-xen-platform-pv-driver-info-result.json", Success (None, Xen_platform_pv_driver_info { product_num=3; build_num=1; });
+  "query-xen-platform-pv-driver-info-result-error-notanint.json", Error (None, { cls="JSONParsing"; descr="Failure(\"int\"):{\"return\": {\"product-num\": \"foo\", \"build-num\": 1}}"; });
 ]
 
 let string_of_file filename =

--- a/lib_test/query-xen-platform-pv-driver-info-result-error-notanint.json
+++ b/lib_test/query-xen-platform-pv-driver-info-result-error-notanint.json
@@ -1,0 +1,1 @@
+{"return": {"product-num": "foo", "build-num": 1}}

--- a/lib_test/query-xen-platform-pv-driver-info-result.json
+++ b/lib_test/query-xen-platform-pv-driver-info-result.json
@@ -1,0 +1,1 @@
+{"return": {"product-num": 3, "build-num": 1}}

--- a/lib_test/query-xen-platform-pv-driver-info.json
+++ b/lib_test/query-xen-platform-pv-driver-info.json
@@ -1,0 +1,1 @@
+{ "execute": "query-xen-platform-pv-driver-info" }


### PR DESCRIPTION
CP-22500: add support for:
- new qmp message query-xen-platform-pv-driver-info
- and add support for new qmp event XEN_PLATFORM_PV_DRIVER_INFO

as defined in qemu.pg/pull-requests/34

