### PR TITLE
Add device_del and qom-list command 

### DIFF
--- a/lib/qmp.ml
+++ b/lib/qmp.ml
@@ -52,6 +52,18 @@ type qom = {
   ty   : string;
 }
 
+type params = {
+  bus     : string;
+  hostbus : string;
+  hostport: string;
+}
+
+type device = {
+  driver : string;
+  id     : string;
+  params : params option;
+}
+
 type command =
   | Qmp_capabilities
   | Query_commands
@@ -70,6 +82,7 @@ type command =
   | Add_fd of int option
   | Remove_fd of int
   | Blockdev_change_medium of string * string
+  | Device_add of string * string * (string * string * string) option
   | Device_del of string
   | Qom_list of string
 
@@ -135,7 +148,6 @@ let message_of_string str =
     ; event     = json |> U.member "event" |> U.to_string
     }
   in
-
   let execute json =
     let arguments = U.member "arguments" in
     let flatten_option = function Some x -> x | None -> None in
@@ -170,6 +182,18 @@ let message_of_string str =
       let filename = json |> arguments |> U.member "filename" |> U.to_string in
       (device, filename)
     in
+    let device_add json =
+      let driver = json |> arguments |> U.member "driver" |> U.to_string in
+      let id     = json |> arguments |> U.member "id"     |> U.to_string in
+      let maybe_mem_of k x = x |> U.member k |> U.to_option U.to_string in
+      let params = json |> arguments |> fun x ->
+      match maybe_mem_of "bus" x, maybe_mem_of "hostbus" x, maybe_mem_of "hostport" x with
+        | Some bus, Some hostbus, Some hostport -> Some (bus, hostbus, hostport)
+        | None, None, None -> None
+        | _ -> failwith (Printf.sprintf "All of bus, hostbus, hostport fields are needed but only some passed in %s" (Y.to_string json))
+      in
+      (driver, id, params)
+    in
     let device_del json =
       json |> arguments |> U.member "id" |> U.to_string
     in
@@ -194,6 +218,7 @@ let message_of_string str =
     | "xen-load-devices-state"   -> json |> xen_load_devices_state   |> fun x -> Xen_load_devices_state x
     | "xen-set-global-dirty-log" -> json |> xen_set_global_dirty_log |> fun x -> Xen_set_global_dirty_log x
     | "blockdev-change-medium"   -> json |> blockdev_change_medium   |> fun (x, y) -> Blockdev_change_medium (x, y)
+    | "device_add"               -> json |> device_add               |> fun (x, y, z) -> Device_add (x, y, z)
     | "device_del"               -> json |> device_del               |> fun x -> Device_del x
     | "qom-list"                 -> json |> qom_list                 |> fun x -> Qom_list x
     | x -> Printf.sprintf "unknown command %s" x |> failwith
@@ -233,14 +258,14 @@ let message_of_string str =
     in
     let qom json =
       let mem_of k x = x |> U.member k |> U.to_string in
-      json |> U.convert_each (fun x -> {name = (mem_of "name" x);ty = (mem_of "type" x)})
+      json |> U.convert_each (fun x -> {name = (mem_of "name" x); ty = (mem_of "type" x)})
     in
     let result =
       let return = json |> U.member "return" in
       return |> function
       | `List  _ -> (return |> U.convert_each U.keys |> List.flatten |> function
-        | x when (subset_of ["name"; "type"] x) -> return |> qom |> fun x -> Qom x
-        | x when (subset_of ["name"] x) -> return |> name_list |> fun x -> Name_list x
+        | x when x |> subset_of ["name"; "type"]  -> return |> qom |> fun x -> Qom x
+        | x when x |> subset_of ["name"]  -> return |> name_list |> fun x -> Name_list x
         | _ -> failwith (Printf.sprintf "unknown result %s" (Y.to_string return))
       )
       | `Assoc _ -> (return |> U.keys |> function
@@ -306,6 +331,11 @@ let json_of_message = function
       | Add_fd id -> "add-fd", (match id with None -> [] | Some x -> [ "fdset-id", `Int x ])
       | Remove_fd id -> "remove-fd", ["fdset-id", `Int id]
       | Blockdev_change_medium (device, filename) -> "blockdev-change-medium", ["device", `String device; "filename", `String filename ]
+      | Device_add (driver, id, params) -> "device_add", (
+        match params with
+        | None -> [ "driver", `String driver; "id", `String id ]
+        | Some (x, y, z) -> [ "driver", `String driver; "id", `String id; "bus", `String x; "hostbus", `String y; "hostport", `String z ]
+      )
       | Device_del id -> "device_del", [ "id", `String id ]
       | Qom_list path -> "qom-list", ["path", `String path ]
     in

--- a/lib/qmp.mli
+++ b/lib/qmp.mli
@@ -35,6 +35,12 @@ type fd_info = {
   fdset_id : int;
 }
 
+(** QOM properties - https://elmarco.fedorapeople.org/qemu-qmp-ref.pdf*)
+type qom = {
+  name : string;
+  ty   : string;
+}
+
 type result =
     Name_list of string list
   | Enabled of enabled
@@ -43,6 +49,7 @@ type result =
   | Xen_platform_pv_driver_info of xen_platform_pv_driver_info
   | Fd_info of fd_info
   | Unit
+  | Qom of qom list
 (** A successful RPC result *)
 
 type greeting = {
@@ -81,6 +88,7 @@ type command =
   | Remove_fd of int
   | Blockdev_change_medium of string * string
   | Device_del of string
+  | Qom_list of string
 (** commands that may be sent to qemu *)
 
 type message =

--- a/lib/qmp.mli
+++ b/lib/qmp.mli
@@ -80,6 +80,7 @@ type command =
   | Add_fd of int option
   | Remove_fd of int
   | Blockdev_change_medium of string * string
+  | Device_del of string
 (** commands that may be sent to qemu *)
 
 type message =

--- a/lib/qmp.mli
+++ b/lib/qmp.mli
@@ -35,10 +35,23 @@ type fd_info = {
   fdset_id : int;
 }
 
-(** QOM properties - https://elmarco.fedorapeople.org/qemu-qmp-ref.pdf*)
+(** QOM properties - https://wiki.qemu.org/index.php/Documentation
+                     https://qemu.weilnetz.de/doc/qemu-qmp-ref.html*)
 type qom = {
   name : string;
   ty   : string;
+}
+
+type params = {
+  bus     : string;
+  hostbus : string;
+  hostport: string;
+}
+
+type device = {
+  driver : string;
+  id     : string;
+  params : params option;
 }
 
 type result =
@@ -87,6 +100,7 @@ type command =
   | Add_fd of int option
   | Remove_fd of int
   | Blockdev_change_medium of string * string
+  | Device_add of string * string * (string * string * string) option
   | Device_del of string
   | Qom_list of string
 (** commands that may be sent to qemu *)

--- a/lib_test/device_add_usbcontroller.json
+++ b/lib_test/device_add_usbcontroller.json
@@ -1,0 +1,1 @@
+{ "execute": "device_add", "arguments": { "driver" : "usb-ehci", "id" : "ehci" } }

--- a/lib_test/device_add_usbdevice.json
+++ b/lib_test/device_add_usbdevice.json
@@ -1,0 +1,1 @@
+{ "execute": "device_add", "arguments":{"driver":"usb-host","id":"usb1","bus":"ehci.0","hostbus":"2","hostport":"2"}}

--- a/lib_test/device_del.json
+++ b/lib_test/device_del.json
@@ -1,0 +1,1 @@
+{"execute": "device_del","arguments":{"id":"usb1"}}

--- a/lib_test/messages.ml
+++ b/lib_test/messages.ml
@@ -49,6 +49,9 @@ let files = [
   "query-xen-platform-pv-driver-info.json", Command (None, Query_xen_platform_pv_driver_info);
   "query-xen-platform-pv-driver-info-result.json", Success (None, Xen_platform_pv_driver_info { product_num=3; build_num=1; });
   "query-xen-platform-pv-driver-info-result-error-notanint.json", Error (None, { cls="JSONParsing"; descr="Expected int, got string \"foo\" in {\"return\": {\"product-num\": \"foo\", \"build-num\": 1}}"; });
+  "device_del.json",               Command (None, Device_del "usb1");
+  "qom_list_peripheral.json",      Command (None, Qom_list "/machine/peripheral");
+  "qom_list_peripheral_result.json", Success (None, Qom [{name="usb1"; ty="child"}; {name="type"; ty="string"}]);
 ]
 
 let string_of_file filename =

--- a/lib_test/messages.ml
+++ b/lib_test/messages.ml
@@ -50,6 +50,8 @@ let files = [
   "query-xen-platform-pv-driver-info-result.json", Success (None, Xen_platform_pv_driver_info { product_num=3; build_num=1; });
   "query-xen-platform-pv-driver-info-result-error-notanint.json", Error (None, { cls="JSONParsing"; descr="Expected int, got string \"foo\" in {\"return\": {\"product-num\": \"foo\", \"build-num\": 1}}"; });
   "device_del.json",               Command (None, Device_del "usb1");
+  "device_add_usbcontroller.json", Command (None, Device_add ("usb-ehci", "ehci", None));
+  "device_add_usbdevice.json",     Command (None, Device_add ("usb-host", "usb1", Some ("ehci.0","2","2")));
   "qom_list_peripheral.json",      Command (None, Qom_list "/machine/peripheral");
   "qom_list_peripheral_result.json", Success (None, Qom [{name="usb1"; ty="child"}; {name="type"; ty="string"}]);
 ]

--- a/lib_test/qom_list_peripheral.json
+++ b/lib_test/qom_list_peripheral.json
@@ -1,0 +1,1 @@
+{"execute":"qom-list","arguments":{"path":"/machine/peripheral"}}

--- a/lib_test/qom_list_peripheral_result.json
+++ b/lib_test/qom_list_peripheral_result.json
@@ -1,0 +1,1 @@
+{"return": [{"name": "usb1", "type": "child"}, {"name":"type", "type": "string"}]}


### PR DESCRIPTION
1. This PR contains two commits : 
    * Add device_del command
    * Add qom-list command to list QOM properties.
2. For first commit (device_del)
    * device_del command can be used to delete a device(eg,usb device)
    * command example:
        {"execute": "device_del","arguments":{"id":"usb1"}}
3. For sencond commit (qom-list) 
    * The QEMU Object Model(qom) provides a framework for registering user
    creatable types and instantiating objects from those types.
    * Qom types can be instantiated and configured directly from the QEMU
    monitor or command-line (eg,-device, device_add).
    * Associated with -device command to plug usb devices to vm, qom-list
    can list these types to check if successfully plugged.
    * Command example:
        {"execute":"qom-list","arguments":{"path":"/machine/peripheral"}}
    result:
        {"return": [{"name": "usb1", "type": "child<usb-host>"}, {"name":"type", "type": "string"}}
       In above example, the usb1 is added by -device command.
