### PR TITLE
CP-24090: Respond to RTC_CHANGE QMP message

### DIFF
--- a/lib/qmp.mli
+++ b/lib/qmp.mli
@@ -72,9 +72,14 @@ type greeting = {
   package : string; (** some information about the (binary?) package *)
 }
 
+type event_data =
+    RTC_CHANGE of int
+   (* extend this to support other qmp events data*)
+
 type event = {
   timestamp : int * int; (** time the event occurred in (seconds, microseconds) *)
   event : string;    (** type of event *)
+  data: event_data option
 }
 
 type error = { cls : string; descr : string; }

--- a/lib_test/messages.ml
+++ b/lib_test/messages.ml
@@ -21,7 +21,7 @@ let files = [
   "capabilities.json",             Command (None, Qmp_capabilities);
   "error.json",                    Error (None, { cls="JSONParsing"; descr="Invalid JSON syntax" });
   "greeting.json",                 Greeting { major = 1; minor = 1; micro = 0; package = " (Debian 1.1.0+dfsg-1)" };
-  "powerdown.json",                Event { timestamp = (1258551470, 802380); event = "POWERDOWN" };
+  "powerdown.json",                Event { timestamp = (1258551470, 802380); event = "POWERDOWN"; data = None };
   "query-commands.json",           Command (None, Query_commands);
   "query-commands-return.json",    Success (None, Name_list [ "qom-list-types"; "change-vnc-password" ]);
   "query_kvm.json",                Command (Some "example", Query_kvm);
@@ -36,7 +36,8 @@ let files = [
   "query-status-result.json",      Success (None, Status "running");
   "query-vnc.json",                Command (None, Query_vnc);
   "query-vnc-result.json",         Success (None, Vnc {enabled=true; auth="none"; family="ipv4"; service=6034; host="127.0.0.1"});
-  "block-io-error.json",           Event { timestamp = (1265044230, 450480); event = "BLOCK_IO_ERROR" };
+  "block-io-error.json",           Event { timestamp = (1265044230, 450480); event = "BLOCK_IO_ERROR"; data = None };
+  "rtc-change.json",               Event { timestamp = (1267020223, 435656); event = "RTC_CHANGE"; data = Some (RTC_CHANGE 78) };
   "xen-save-devices-state.json",   Command (None, Xen_save_devices_state "/tmp/qemu-save");
   "xen-load-devices-state.json",   Command (None, Xen_load_devices_state "/tmp/qemu-resume");
   "xen-set-global-dirty-log.json", Command (None, Xen_set_global_dirty_log true);

--- a/lib_test/rtc-change.json
+++ b/lib_test/rtc-change.json
@@ -1,0 +1,3 @@
+{ "event": "RTC_CHANGE",
+    "data": { "offset": 78 },
+    "timestamp": { "seconds": 1267020223, "microseconds": 435656 } }


### PR DESCRIPTION
Add support for the RTC_CHANGE event

Example:
{ "event": "RTC_CHANGE",
    "data": { "offset": 78 },
    "timestamp": { "seconds": 1267020223, "microseconds": 435656 } }

Signed-off-by: Liang Dai <liang.dai1@citrix.com>