### PR TITLE
CP-27111: generalise QMP device-add to support VCPU devices

### DIFF
--- a/lib/qmp.ml
+++ b/lib/qmp.ml
@@ -67,6 +67,8 @@ module Device = struct
       let all = List.map string_of [ QEMU32_I386_CPU ]
     end
     type t = { id: string; socket_id: int; core_id: int; thread_id: int; }
+    let id_of ~socket_id ~core_id ~thread_id =
+      Printf.sprintf "cpu-%d-%d-%d" socket_id core_id thread_id
     (* according to qapi schema at https://github.com/qemu/qemu/blob/master/qapi-schema.json#L3093 *)
     type hotpluggable_t = { driver_type: string; vcpus_count: int; props: t; qom_path: string option; }
   end
@@ -322,7 +324,7 @@ let message_of_string str =
         let thread_id = json |> U.member "thread-id" |> U.to_int in
         let id        = try json |> U.member "id"    |> U.to_string
           with _ -> (* adopt unique id if none is returned by qmp *)
-            Printf.sprintf "cpu-%d-%d-%d" socket_id core_id thread_id
+            Device.VCPU.id_of ~socket_id ~core_id ~thread_id
         in
           Device.VCPU.{ id; socket_id; core_id; thread_id }
       in

--- a/lib/qmp.mli
+++ b/lib/qmp.mli
@@ -42,16 +42,18 @@ type qom = {
   ty   : string;
 }
 
-type params = {
-  bus     : string;
-  hostbus : string;
-  hostport: string;
-}
+module Device : sig
+  module USB : sig
+    type params_t = { bus: string; hostbus: string; hostport: string; }
+    type t = { id: string; params: params_t option }
+  end
+  type t = USB of USB.t
+end
 
-type device = {
-  driver : string;
-  id     : string;
-  params : params option;
+(* according to qapi schema at https://github.com/qemu/qemu/blob/master/qapi-schema.json#L1478 *)
+type device_add_t = {
+  driver : string; (* only required field is driver *)
+  device : Device.t;
 }
 
 type result =
@@ -111,7 +113,7 @@ type command =
   | Add_fd of int option
   | Remove_fd of int
   | Blockdev_change_medium of string * string
-  | Device_add of string * string * (string * string * string) option
+  | Device_add of device_add_t
   | Device_del of string
   | Qom_list of string
 (** commands that may be sent to qemu *)

--- a/lib/qmp.mli
+++ b/lib/qmp.mli
@@ -44,10 +44,21 @@ type qom = {
 
 module Device : sig
   module USB : sig
+    module Driver : sig
+      type t = USB_EHCI | USB_HOST
+      val string_of : t -> string
+    end
     type params_t = { bus: string; hostbus: string; hostport: string; }
     type t = { id: string; params: params_t option }
   end
-  type t = USB of USB.t
+  module VCPU : sig
+    module Driver : sig
+      type t = QEMU32_I386_CPU
+      val string_of : t -> string
+    end
+    type t = { id: string; socket_id: int; core_id: int; thread_id: int; }
+  end
+  type t = USB of USB.t | VCPU of VCPU.t
 end
 
 (* according to qapi schema at https://github.com/qemu/qemu/blob/master/qapi-schema.json#L1478 *)

--- a/lib/qmp.mli
+++ b/lib/qmp.mli
@@ -57,6 +57,7 @@ module Device : sig
       val string_of : t -> string
     end
     type t = { id: string; socket_id: int; core_id: int; thread_id: int; }
+    val id_of : socket_id: int -> core_id: int -> thread_id: int -> string
     type hotpluggable_t = { driver_type: string; vcpus_count: int; props: t; qom_path: string option; }
   end
   type t = USB of USB.t | VCPU of VCPU.t

--- a/lib/qmp.mli
+++ b/lib/qmp.mli
@@ -57,6 +57,7 @@ module Device : sig
       val string_of : t -> string
     end
     type t = { id: string; socket_id: int; core_id: int; thread_id: int; }
+    type hotpluggable_t = { driver_type: string; vcpus_count: int; props: t; qom_path: string option; }
   end
   type t = USB of USB.t | VCPU of VCPU.t
 end
@@ -73,6 +74,7 @@ type result =
   | Status of string
   | Vnc of vnc
   | Xen_platform_pv_driver_info of xen_platform_pv_driver_info
+  | Hotpluggable_cpus of Device.VCPU.hotpluggable_t list
   | Fd_info of fd_info
   | Unit
   | Qom of qom list
@@ -113,6 +115,7 @@ type command =
   | Query_status
   | Query_vnc
   | Query_xen_platform_pv_driver_info
+  | Query_hotpluggable_cpus
   | Stop
   | Cont
   | Eject of string * bool option

--- a/lib_test/device_add_vcpu.json
+++ b/lib_test/device_add_vcpu.json
@@ -1,0 +1,1 @@
+{ "execute": "device_add", "arguments":{"driver":"qemu32-i386-cpu","id":"cpu-1-2-0","socket-id":1,"core-id":2,"thread-id":0}}

--- a/lib_test/messages.ml
+++ b/lib_test/messages.ml
@@ -54,8 +54,9 @@ let files = [
   "query-xen-platform-pv-driver-info-result.json", Success (None, Xen_platform_pv_driver_info { product_num=3; build_num=1; });
   "query-xen-platform-pv-driver-info-result-error-notanint.json", Error (None, { cls="JSONParsing"; descr="Expected int, got string \"foo\" in {\"return\": {\"product-num\": \"foo\", \"build-num\": 1}}"; });
   "device_del.json",               Command (None, Device_del "usb1");
-  "device_add_usbcontroller.json", Command (None, Device_add { driver="usb-ehci"; device=USB { id="ehci"; params=None}});
-  "device_add_usbdevice.json",     Command (None, Device_add { driver="usb-host"; device=USB { id="usb1"; params=Some { bus="ehci.0"; hostbus="2"; hostport="2"}}});
+  "device_add_usbcontroller.json", Command (None, Device_add { driver=Device.USB.Driver.(string_of USB_EHCI); device=USB { id="ehci"; params=None}});
+  "device_add_usbdevice.json",     Command (None, Device_add { driver=Device.USB.Driver.(string_of USB_HOST); device=USB { id="usb1"; params=Some { bus="ehci.0"; hostbus="2"; hostport="2"}}});
+  "device_add_vcpu.json",          Command (None, Device_add { driver=Device.VCPU.Driver.(string_of QEMU32_I386_CPU); device=VCPU {id="cpu-1-2-0";socket_id=1;core_id=2;thread_id=0}});
   "qom_list_peripheral.json",      Command (None, Qom_list "/machine/peripheral");
   "qom_list_peripheral_result.json", Success (None, Qom [{name="usb1"; ty="child"}; {name="type"; ty="string"}]);
 ]

--- a/lib_test/messages.ml
+++ b/lib_test/messages.ml
@@ -54,8 +54,8 @@ let files = [
   "query-xen-platform-pv-driver-info-result.json", Success (None, Xen_platform_pv_driver_info { product_num=3; build_num=1; });
   "query-xen-platform-pv-driver-info-result-error-notanint.json", Error (None, { cls="JSONParsing"; descr="Expected int, got string \"foo\" in {\"return\": {\"product-num\": \"foo\", \"build-num\": 1}}"; });
   "device_del.json",               Command (None, Device_del "usb1");
-  "device_add_usbcontroller.json", Command (None, Device_add ("usb-ehci", "ehci", None));
-  "device_add_usbdevice.json",     Command (None, Device_add ("usb-host", "usb1", Some ("ehci.0","2","2")));
+  "device_add_usbcontroller.json", Command (None, Device_add { driver="usb-ehci"; device=USB { id="ehci"; params=None}});
+  "device_add_usbdevice.json",     Command (None, Device_add { driver="usb-host"; device=USB { id="usb1"; params=Some { bus="ehci.0"; hostbus="2"; hostport="2"}}});
   "qom_list_peripheral.json",      Command (None, Qom_list "/machine/peripheral");
   "qom_list_peripheral_result.json", Success (None, Qom [{name="usb1"; ty="child"}; {name="type"; ty="string"}]);
 ]

--- a/lib_test/messages.ml
+++ b/lib_test/messages.ml
@@ -53,6 +53,8 @@ let files = [
   "query-xen-platform-pv-driver-info.json", Command (None, Query_xen_platform_pv_driver_info);
   "query-xen-platform-pv-driver-info-result.json", Success (None, Xen_platform_pv_driver_info { product_num=3; build_num=1; });
   "query-xen-platform-pv-driver-info-result-error-notanint.json", Error (None, { cls="JSONParsing"; descr="Expected int, got string \"foo\" in {\"return\": {\"product-num\": \"foo\", \"build-num\": 1}}"; });
+  "query-hotpluggable-cpus.json", Command (None, Query_hotpluggable_cpus);
+  "query-hotpluggable-cpus-result.json", Success (None, Hotpluggable_cpus [ { qom_path=None; driver_type=Device.VCPU.Driver.(string_of QEMU32_I386_CPU); vcpus_count=1; props={id="cpu-1-2-3"; socket_id=1; core_id=2; thread_id=3 }}; { qom_path=Some "/machine/unattached/device[1]"; driver_type=Device.VCPU.Driver.(string_of QEMU32_I386_CPU); vcpus_count=1; props={id="cpu-0-0-0"; socket_id=0; core_id=0; thread_id=0}} ]);
   "device_del.json",               Command (None, Device_del "usb1");
   "device_add_usbcontroller.json", Command (None, Device_add { driver=Device.USB.Driver.(string_of USB_EHCI); device=USB { id="ehci"; params=None}});
   "device_add_usbdevice.json",     Command (None, Device_add { driver=Device.USB.Driver.(string_of USB_HOST); device=USB { id="usb1"; params=Some { bus="ehci.0"; hostbus="2"; hostport="2"}}});

--- a/lib_test/query-hotpluggable-cpus-result.json
+++ b/lib_test/query-hotpluggable-cpus-result.json
@@ -1,0 +1,1 @@
+{"return": [{"type": "qemu32-i386-cpu", "vcpus-count": 1, "props": {"socket-id": 1, "core-id": 2, "thread-id": 3}}, {"qom-path": "/machine/unattached/device[1]", "type": "qemu32-i386-cpu", "vcpus-count": 1, "props": {"socket-id": 0, "core-id": 0, "thread-id": 0}}]}

--- a/lib_test/query-hotpluggable-cpus.json
+++ b/lib_test/query-hotpluggable-cpus.json
@@ -1,0 +1,1 @@
+{ "execute": "query-hotpluggable-cpus" }


### PR DESCRIPTION
- Generalise the QMP device-add command using stronger typing, following closer the the qapi specification, so that it can be used to add different types of devices instead of only USB devices.
- Add a new VCPU device to device-add, to support hotplugging VCPUs
- Add a new VCPU query command

The stronger-typed QMP device-add argument used to distinguish between different types of devices means that this change needs to be added together with a corresponding change in xenopsd for the existing usage of Device_add for USB devices.

Signed-off-by: Marcus Granado <marcus.granado@citrix.com> 

This PR needs to be added at the same time as https://github.com/xapi-project/xenopsd/pull/464