### PR TITLE
Remove test in Travis for OCaml 4.02.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ env:
     - PACKAGE="qmp"
     - DISTRO="debian-unstable"
   matrix:
-    - OCAML_VERSION=4.02.3 BASE_REMOTE=git://github.com/xapi-project/xs-opam#1.8.0
     - OCAML_VERSION=4.04.2 BASE_REMOTE=git://github.com/xapi-project/xs-opam
     - OCAML_VERSION=4.04.2 EXTRA_REMOTES=git://github.com/xapi-project/xs-opam
 matrix:


### PR DESCRIPTION
We no longer support Ocaml 4.02.3 and we haev seen an error when
designating a specific version of xs-opam in Travis:

fatal: remote error:
  xapi-project/xs-opam#1.8.0 is not a valid repository name

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>