### PR TITLE
CP-29936: add query-migratable QMP command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,12 @@
 language: c
 sudo: required
-install:
-  - wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-docker.sh
-script:
-  - cp qmp.opam opam
-  - bash -ex .travis-docker.sh
+service: docker
+install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-docker.sh
+script: bash -ex .travis-docker.sh
 env:
   global:
-    - PINS="qmp:."
     - PACKAGE="qmp"
-    - DISTRO="debian-unstable"
+    - PINS="qmp:."
+    - BASE_REMOTE="https://github.com/xapi-project/xs-opam.git"
   matrix:
-    - OCAML_VERSION=4.04.2 BASE_REMOTE=git://github.com/xapi-project/xs-opam
-    - OCAML_VERSION=4.04.2 EXTRA_REMOTES=git://github.com/xapi-project/xs-opam
-matrix:
-  fast_finish: true
-  allow_failures:
-    - env: OCAML_VERSION=4.04.2 EXTRA_REMOTES=git://github.com/xapi-project/xs-opam
-
+    - DISTRO="debian-9-ocaml-4.06"

--- a/lib/qmp.ml
+++ b/lib/qmp.ml
@@ -95,6 +95,7 @@ type command =
   | Query_vnc
   | Query_xen_platform_pv_driver_info
   | Query_hotpluggable_cpus
+  | Query_migratable
   | Stop
   | Cont
   | Eject of string * bool option
@@ -280,6 +281,7 @@ let message_of_string str =
     | "query-kvm"                -> Query_kvm
     | "query-xen-platform-pv-driver-info" -> Query_xen_platform_pv_driver_info
     | "query-hotpluggable-cpus"  -> Query_hotpluggable_cpus
+    | "query-migratable"         -> Query_migratable
     | "eject"                    -> json |> eject  |> fun (x, y) -> Eject (x, y)
     | "change"                   -> json |> change |> fun (x, y, z) -> Change (x, y, z)
     | "add-fd"                   -> json |> add_fd |> fun x -> Add_fd x
@@ -407,6 +409,7 @@ let json_of_message = function
       | Query_kvm -> "query-kvm", []
       | Query_xen_platform_pv_driver_info -> "query-xen-platform-pv-driver-info", []
       | Query_hotpluggable_cpus -> "query-hotpluggable-cpus" , []
+      | Query_migratable -> "query-migratable", []
       | Eject (device, None) -> "eject", [ "device", `String device ]
       | Eject (device, Some force) -> "eject", [ "device", `String device; "force", `Bool force ]
       | Change (device, target, None) -> "change", [ "device", `String device; "target", `String target ]

--- a/lib/qmp.mli
+++ b/lib/qmp.mli
@@ -124,6 +124,7 @@ type command =
   | Query_vnc
   | Query_xen_platform_pv_driver_info
   | Query_hotpluggable_cpus
+  | Query_migratable
   | Stop
   | Cont
   | Eject of string * bool option

--- a/lib_test/messages.ml
+++ b/lib_test/messages.ml
@@ -36,6 +36,8 @@ let files = [
   "query-status-result.json",      Success (None, Status "running");
   "query-vnc.json",                Command (None, Query_vnc);
   "query-vnc-result.json",         Success (None, Vnc {enabled=true; auth="none"; family="ipv4"; service=6034; host="127.0.0.1"});
+  "query-migratable.json",         Command (None, Query_migratable);
+  "query-migratable-error.json",   Error (None, { cls = "GenericError"; descr = "State blocked by non-migratable device '0000:00:07.0/nvme'" });
   "event-block-io-error.json",     Event { timestamp = (1265044230, 450480); event = "BLOCK_IO_ERROR"; data = None };
   "event-rtc-change.json",         Event { timestamp = (1267020223, 435656); event = "RTC_CHANGE"; data = Some (RTC_CHANGE 78L) };
   "event-xen-platform-pv-driver-info.json",

--- a/lib_test/query-migratable-error.json
+++ b/lib_test/query-migratable-error.json
@@ -1,0 +1,1 @@
+{"error": {"class": "GenericError", "desc": "State blocked by non-migratable device '0000:00:07.0/nvme'"}}

--- a/lib_test/query-migratable.json
+++ b/lib_test/query-migratable.json
@@ -1,0 +1,1 @@
+{ "execute": "query-migratable" }

--- a/qmp.opam
+++ b/qmp.opam
@@ -1,4 +1,4 @@
-opam-version: "1.2"
+opam-version: "2.0"
 maintainer: "xen-api@lists.xen.org"
 authors: [ "Dave Scott" ]
 homepage: "https://github.com/xapi-project/ocaml-qmp"
@@ -7,13 +7,21 @@ tags: [
   "org:mirage"
   "org:xapi-project"
 ]
-build: [["jbuilder" "build" "-p" name "-j" jobs]]
-build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+  ["jbuilder" "runtest" "-p" name "-j" jobs] {with-test}
+]
 depends: [
+  "ocaml"
   "base-unix"
-  "jbuilder"  {build}
+  "jbuilder" {build}
   "yojson"
   "cmdliner"
-  "ounit"     {test}
+  "ounit" {with-test}
 ]
 dev-repo: "git://github.com/xapi-project/ocaml-qmp"
+synopsis: "OCaml implementation of a Qemu Message Protocol (QMP) client"
+url {
+  src: "https://github.com/xapi-project/ocaml-qmp/archive/0.14.0.tar.gz"
+  checksum: "md5=9b017dcb8154215ec286ec548955a553"
+}


### PR DESCRIPTION
This will be useful to check that a VM is migratable before reaching the
point of no return during migration.
E.g. VMs that have NVME devices are not migratable, but they become
migratable when the PV drivers detach them.

It is safer to ask QEMU whether it is migratable than to rely on the
presence of PV drivers to determine this (could be that you have PV  drivers but the device failed to unplug for some reason).

There will be coresponding changes in xenopsd/xapi, but this PR is independent of that.