### PR TITLE
CP-30136: fix PCI device add: there is no dev and fn in the JSON protocol, only addr

### DIFF
--- a/cli/cli.ml
+++ b/cli/cli.ml
@@ -16,7 +16,6 @@ let project_url = "http://github.com/djs55/ocaml-qmp"
 
 let default_path = ref "/tmp/qmp"
 
-open Common
 open Cmdliner
 
 (* Help sections common to all commands *)

--- a/lib/qmp.ml
+++ b/lib/qmp.ml
@@ -270,8 +270,8 @@ let message_of_string str =
 
       let device_add_pci json =
         let id          = json |> arguments |> U.member "id"         |> U.to_string in
-        let dev         = json |> arguments |> U.member "dev"        |> U.to_int in
-        let fn          = json |> arguments |> U.member "fn"         |> U.to_int in
+        let addr        = json |> arguments |> U.member "addr"       |> U.to_string in
+        Scanf.sscanf addr "%x.%x" @@ fun dev fn ->
         let hostaddr    = json |> arguments |> U.member "hostaddr"   |> U.to_string in
         let permissive  = json |> arguments |> U.member "permissive" |> U.to_bool in
         Device.PCI {id; dev; fn; hostaddr; permissive; }
@@ -465,7 +465,9 @@ let json_of_message = function
           | Some {Device.USB.bus; hostbus; hostport} -> [ "id", `String id; "bus", `String bus; "hostbus", `String hostbus; "hostport", `String hostport ]
           )
         | Device.VCPU {id; socket_id; core_id; thread_id } -> [ "id", `String id; "socket-id", `Int socket_id; "core-id", `Int core_id; "thread-id", `Int thread_id ]
-        | Device.PCI { id; dev; fn; hostaddr; permissive; } -> [ "id", `String id ; "dev", `Int dev; "fn", `Int fn; "hostaddr", `String hostaddr; "permissive", `Bool permissive ]
+        | Device.PCI { id; dev; fn; hostaddr; permissive; } ->
+          let addr = Printf.sprintf "%x.%x" dev fn in
+          [ "id", `String id ; "addr", `String addr; "hostaddr", `String hostaddr; "permissive", `Bool permissive ]
       )
       | Device_del id -> "device_del", [ "id", `String id ]
       | Qom_list path -> "qom-list", ["path", `String path ]

--- a/lib/qmp.mli
+++ b/lib/qmp.mli
@@ -97,11 +97,11 @@ type greeting = {
 
 type event_data =
 
-    (** emitted when the guest changes the RTC time *)
   | RTC_CHANGE of int64
+    (** emitted when the guest changes the RTC time *)
 
-    (** emitted when the XEN PV driver writes build number to io-port 0x10, marking the end of the preamble *)
   | XEN_PLATFORM_PV_DRIVER_INFO of xen_platform_pv_driver_info
+    (** emitted when the XEN PV driver writes build number to io-port 0x10, marking the end of the preamble *)
 
    (* extend this to support other qmp events data*)
 
@@ -162,4 +162,4 @@ val _JSONParsing : string
 val message_of_string : string -> message
 val string_of_message : message -> string
 
-val json_of_message : message -> Yojson.Safe.json
+val json_of_message : message -> Yojson.Safe.t

--- a/lib_test/device_add_pci.json
+++ b/lib_test/device_add_pci.json
@@ -1,1 +1,1 @@
-{ "execute": "device_add", "arguments":{"driver":"xen-pci-passthrough","id":"pci","dev":0, "fn":0, "hostaddr":"some_address", "permissive":true}}
+{ "execute": "device_add", "arguments":{"driver":"xen-pci-passthrough","id":"pci","addr":"a.0", "hostaddr":"some_address", "permissive":true}}

--- a/lib_test/messages.ml
+++ b/lib_test/messages.ml
@@ -61,7 +61,7 @@ let files = [
   "device_add_usbcontroller.json", Command (None, Device_add { driver=Device.USB.Driver.(string_of USB_EHCI); device=USB { id="ehci"; params=None}});
   "device_add_usbdevice.json",     Command (None, Device_add { driver=Device.USB.Driver.(string_of USB_HOST); device=USB { id="usb1"; params=Some { bus="ehci.0"; hostbus="2"; hostport="2"}}});
   "device_add_vcpu.json",          Command (None, Device_add { driver=Device.VCPU.Driver.(string_of QEMU32_I386_CPU); device=VCPU {id="cpu-1-2-0";socket_id=1;core_id=2;thread_id=0}});
-  "device_add_pci.json",            Command (None, Device_add { driver=Device.PCI.Driver.(string_of XEN_PCI_PASSTHROUGH); device=PCI {id="pci"; dev=0; fn=0; hostaddr="some_address"; permissive=true }});
+  "device_add_pci.json",            Command (None, Device_add { driver=Device.PCI.Driver.(string_of XEN_PCI_PASSTHROUGH); device=PCI {id="pci"; dev=0xa; fn=0; hostaddr="some_address"; permissive=true }});
   "qom_list_peripheral.json",      Command (None, Qom_list "/machine/peripheral");
   "qom_list_peripheral_result.json", Success (None, Qom [{name="usb1"; ty="child"}; {name="type"; ty="string"}]);
 ]


### PR DESCRIPTION
Now that https://github.com/xapi-project/xenopsd/pull/620 is close to
working I was able to test this and Qemu rejected the QMP command.

The proper way to specify the device:function for the guest is to use
`addr` as seen here:
https://github.com/mirage/xen/blob/7c2c176/tools/libxl/libxl_qmp.c#L866-L869

With the updated QMP command Qemu no longer rejects the command.
