### PR TITLE
CP-30136: allow optional guest PCI address

### DIFF
--- a/lib/qmp.mli
+++ b/lib/qmp.mli
@@ -65,7 +65,7 @@ module Device : sig
       type t = XEN_PCI_PASSTHROUGH
       val string_of : t -> string
     end
-    type t = {id: string; dev: int; fn: int; hostaddr: string; permissive: bool;}
+    type t = {id: string; devfn: (int * int) option; hostaddr: string; permissive: bool;}
   end
   type t = USB of USB.t | VCPU of VCPU.t | PCI of PCI.t
 end

--- a/lib_test/messages.ml
+++ b/lib_test/messages.ml
@@ -61,7 +61,7 @@ let files = [
   "device_add_usbcontroller.json", Command (None, Device_add { driver=Device.USB.Driver.(string_of USB_EHCI); device=USB { id="ehci"; params=None}});
   "device_add_usbdevice.json",     Command (None, Device_add { driver=Device.USB.Driver.(string_of USB_HOST); device=USB { id="usb1"; params=Some { bus="ehci.0"; hostbus="2"; hostport="2"}}});
   "device_add_vcpu.json",          Command (None, Device_add { driver=Device.VCPU.Driver.(string_of QEMU32_I386_CPU); device=VCPU {id="cpu-1-2-0";socket_id=1;core_id=2;thread_id=0}});
-  "device_add_pci.json",            Command (None, Device_add { driver=Device.PCI.Driver.(string_of XEN_PCI_PASSTHROUGH); device=PCI {id="pci"; dev=0xa; fn=0; hostaddr="some_address"; permissive=true }});
+  "device_add_pci.json",            Command (None, Device_add { driver=Device.PCI.Driver.(string_of XEN_PCI_PASSTHROUGH); device=PCI {id="pci"; devfn=Some(0xa, 0); hostaddr="some_address"; permissive=true }});
   "qom_list_peripheral.json",      Command (None, Qom_list "/machine/peripheral");
   "qom_list_peripheral_result.json", Success (None, Qom [{name="usb1"; ty="child"}; {name="type"; ty="string"}]);
 ]


### PR DESCRIPTION
The guest PCI address is optional, see https://github.com/mirage/xen/blob/master/tools/libxl/libxl_qmp.c#L866-L869
Having it as an `Pci.address option` on the OCaml side gives us more flexibility in choosing whether Qemu assigns the PCI addresses or xenopsd.