### PR TITLE
CA-318579 add "query-chardev" command

### DIFF
--- a/lib/qmp.mli
+++ b/lib/qmp.mli
@@ -35,6 +35,12 @@ type fd_info = {
   fdset_id : int;
 }
 
+type char_device = {
+  label         : string;
+  filename      : string;
+  frontend_open : bool;
+}
+
 (** QOM properties - https://wiki.qemu.org/index.php/Documentation
                      https://qemu.weilnetz.de/doc/qemu-qmp-ref.html*)
 type qom = {
@@ -86,6 +92,8 @@ type result =
   | Fd_info of fd_info
   | Unit
   | Qom of qom list
+  | Char_devices of char_device list
+
 (** A successful RPC result *)
 
 type greeting = {
@@ -133,6 +141,7 @@ type command =
   | Query_hotpluggable_cpus
   | Query_migratable
   | Query_pci
+  | Query_chardev
   | Stop
   | Cont
   | Eject of string * bool option

--- a/lib_test/messages.ml
+++ b/lib_test/messages.ml
@@ -36,6 +36,14 @@ let files = [
   "query-status-result.json",      Success (None, Status "running");
   "query-vnc.json",                Command (None, Query_vnc);
   "query-vnc-result.json",         Success (None, Vnc {enabled=true; auth="none"; family="ipv4"; service=6034; host="127.0.0.1"});
+  "query-chardev.json",            Command (None, Query_chardev);
+  "query-chardev-result.json",     Success (None, Char_devices
+                                    [{ label="monitor"
+                                     ; filename="stdio"
+                                     ; frontend_open=true}
+                                    ;{ label="serial0"
+                                     ; filename = "vc"
+                                     ; frontend_open=false}]);
   "query-migratable.json",         Command (None, Query_migratable);
   "query-migratable-error.json",   Error (None, { cls = "GenericError"; descr = "State blocked by non-migratable device '0000:00:07.0/nvme'" });
   "event-block-io-error.json",     Event { timestamp = (1265044230, 450480); event = "BLOCK_IO_ERROR"; data = None };

--- a/lib_test/query-chardev-result.json
+++ b/lib_test/query-chardev-result.json
@@ -1,0 +1,15 @@
+{
+  "return": [
+    {
+      "label": "monitor",
+      "filename": "stdio",
+      "frontend-open": true
+
+    },
+    {
+      "label": "serial0",
+      "filename": "vc",
+      "frontend-open": false
+    }
+  ]
+}

--- a/lib_test/query-chardev.json
+++ b/lib_test/query-chardev.json
@@ -1,0 +1,2 @@
+
+{ "execute": "query-chardev" }


### PR DESCRIPTION
This adds support for the query-chardev command and its result; it
includes a new test. Below is the specification:

    query-chardev
    -------------

    Each device is represented by a json-object. The returned value is a
    json-array of all devices.

    Each json-object contain the following:

    - "label": device's label (json-string)
    - "filename": device's file (json-string)

    Example:

    -> { "execute": "query-chardev" }
    <- {
          "return":[
             {
                "label":"monitor",
                "filename":"stdio"
             },
             {
                "label":"serial0",
                "filename":"vc"
             }
          ]
       }

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>