### PR TITLE
Bump minimal dependency version of Yojson

### DIFF
--- a/qmp.opam
+++ b/qmp.opam
@@ -16,7 +16,7 @@ depends: [
   "ocaml"
   "base-unix"
   "dune" {build}
-  "yojson"
+  "yojson" {>= "1.6.0"}
   "cmdliner"
   "ounit2" {with-test}
 ]


### PR DESCRIPTION
Yojson introduced `t` in 1.6.0, so this code needs to depend on that version at least.